### PR TITLE
Avoid OOM error in process `make_project_file`

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -663,6 +663,8 @@ process run_tsne {
 process make_project_file {
     publishDir params.result_dir_path, mode: 'copy'
 
+    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'ignore' }
+
     container params.scanpy_scripts_container
 
     input:


### PR DESCRIPTION
The following error was found when running `final_project.py` for a dataset with approx 900k cells

```
slurmstepd: error: Detected 1 oom_kill event in StepId=34943334.batch. Some of the step tasks have been OOM Killed.
```