### PR TITLE
Use Leiden clustering instead of Louvain

### DIFF
--- a/bin/final_project.py
+++ b/bin/final_project.py
@@ -49,7 +49,7 @@ obs_sources = [file for file in os.listdir(source_dir) if file.startswith('obs_s
 for idx, obs_source_file in enumerate(sorted(obs_sources)):
     ad_s = sc.read(os.path.join(source_dir, obs_source_file))
     if adata.n_obs == ad_s.n_obs and all(adata.obs_names == ad_s.obs_names):
-        keys_to_copy = (k for k in ad_s.obs.keys() if "louvain" in k)
+        keys_to_copy = (k for k in ad_s.obs.keys() if "leiden" in k)
         for k_to_copy in keys_to_copy:
             suffix = ''
             if k_to_copy in adata.obs:

--- a/main.nf
+++ b/main.nf
@@ -12,7 +12,7 @@ params.celltype_field = 'NO_CELLTYPE_FIELD'
 params.neighbor_values = ['3', '5', '10', '15', '20', '25', '30', '50', '100']
 params.perplexity_values = ['1', '5', '10', '15', '20', '25', '30', '35', '40', '45', '50']
 params.resolution_values = ['0.1', '0.3', '0.5', '0.7', '1.0', '2.0', '3.0', '4.0', '5.0']
-params.slotname = "louvain_resolution"
+params.slotname = "leiden_resolution"
 params.clustering_slotname = params.resolution_values.collect { params.slotname + "_" + it }
 params.merged_group_slotname = params.clustering_slotname + [params.celltype_field]
 

--- a/modules/scanpy-scripts/find_clusters.nf
+++ b/modules/scanpy-scripts/find_clusters.nf
@@ -12,9 +12,9 @@ process FIND_CLUSTERS {
     def args    = task.ext.args ?: ""
     """
         export PYTHONIOENCODING='utf-8'
-        scanpy-find-cluster louvain \
+        scanpy-find-cluster leiden \
         --neighbors-key 'neighbors' \
-        --key-added 'louvain_resolution_${resolution}' \
+        --key-added 'leiden_resolution_${resolution}' \
         --resolution ${resolution} \
         --random-state '1234' \
         --directed \


### PR DESCRIPTION
This changes the clustering method the pipeline uses from the Louvain method to the Leiden method.  Reasons:
- the Leiden algorithm is an improvement over the Louvain algorithm, and studies have shown that Leiden outperforms Louvain in clustering analysis on single-cell transcriptomic data sets ([Traag and van Eck, 2019](https://www.nature.com/articles/s41598-019-41695-z), [Duò and Robinson, 2018](https://f1000research.com/articles/7-1141/v3), [Freytag et al., 2018](https://f1000research.com/articles/7-1297/v2), [Weber and Robinson, 2016](https://onlinelibrary.wiley.com/doi/full/10.1002/cyto.a.23030)).
- the Louvain is no longer maintained

This addresses [issue 35](https://github.com/ebi-gene-expression-group/scxa-tertiary-workflow/issues/35).