### PR TITLE
Make wf run singularity by default

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -67,6 +67,8 @@ dag {
     overwrite               = true
 }
 
+singularity.enabled = true
+
 profiles {
     atlas {
         process {
@@ -91,9 +93,10 @@ profiles {
             enabled = true
             runOptions = "--platform linux/amd64"
         }
+        singularity.enabled = false
     }
 
-    singularity {
-        singularity.enabled = true
-    }
+    // singularity {
+    //     singularity.enabled = true
+    // }
 }


### PR DESCRIPTION
Changes here make sure that Singularity is enabled by default.  This feature was probably removed during one of the previous merge conflict resolutions, as README notes that default is Singularity and includes instructions on how to run 
Docker instead. 

```
The workflow uses Singularity by default, but users can add the `-profile docker` to run using Docker.
```
Once passing tests, we can merge to `hackathon` then update submodule in this PR:
https://github.com/ebi-gene-expression-group/scxa-workflows/pull/45